### PR TITLE
Archipelago GSTLA Expand Filler Options

### DIFF
--- a/worlds/gstla/GameData.py
+++ b/worlds/gstla/GameData.py
@@ -220,7 +220,8 @@ class GameData:
         self.item_names: Dict[int, ItemName] = dict()
         self.events: Dict[int, EventDatum] = dict()
         self.vanilla_item_ids: Set[int] = set()
-        self.vanilla_shop_contents: Set[int] = set()
+        self.shop_basic_equipment: Set[int] = set()
+        self.shop_artifacts: Set[int] = set()
         self.forgeable_ids: Set[int] = set()
         self.lucky_medal_ids: Set[int] = {
             # 23, # Assassin Blade
@@ -350,10 +351,10 @@ class GameData:
         for shop in shop_data:
             for id in shop['items']:
                 if id != 0:
-                    self.vanilla_shop_contents.add(id)
+                    self.shop_basic_equipment.add(id)
             for artifact in shop['artifacts']:
                 if artifact != 0:
-                    self.vanilla_shop_contents.add(artifact)
+                    self.shop_artifacts.add(artifact)
 
     def _load_forgeables(self):
         with open(os.path.join(SCRIPT_DIR, 'data', 'forgeables.json'), 'r') as forge_file:

--- a/worlds/gstla/Items.py
+++ b/worlds/gstla/Items.py
@@ -4,10 +4,11 @@ from .gen.InternalItemData import InternalItemData
 from .gen.LocationNames import loc_names_by_id
 from .gen.ItemNames import ItemName
 from .gen.LocationNames import LocationName
-from .gen.ItemData import (ItemData, events, mimics, psyenergy_as_item_list, psyenergy_list, summon_list, other_progression,
-                           forge_only, lucky_only, shop_only, vanilla_coins, remainder, useful_consumables, stat_boosters, 
-                           useful_consumables, forge_materials, useful_remainder, class_change_items, rusty_items,
-                           TrapType, FillerType, all_items as all_gen_items, djinn_items, characters as character_items)
+from .gen.ItemData import (ItemData, events, mimics, psyenergy_as_item_list, psyenergy_list, summon_list,
+                           other_progression, forge_only, lucky_only, vanilla_coins, remainder, stat_boosters,
+                           useful_consumables, forge_materials, chest_equipment, class_change_items, rusty_items,
+                           TrapType, FillerType, all_items as all_gen_items, djinn_items, characters as character_items,
+                           shop_basic_equipment, non_vanilla, shop_artifacts)
 from .gen.LocationData import LocationType, location_type_to_data
 from .GameData import ItemType
 
@@ -230,7 +231,7 @@ def create_items(world: 'GSTLAWorld', player: int):
         world.multiworld.itempool.append(ap_item)
         sum_locations -= 1
 
-    for item in useful_remainder:
+    for item in chest_equipment:
         ap_item = create_filler(world, item)
         world.multiworld.itempool.append(ap_item)
         sum_locations -= 1
@@ -338,8 +339,17 @@ def get_filler_item(world: 'GSTLAWorld', includetraps: bool = True) -> ItemData:
         elif filler_type == FillerType.LuckyEquipment:
             item = world.random.choice(lucky_only)
 
-        elif filler_type == FillerType.ShopEquipment:
-            item = world.random.choice(shop_only)
+        elif filler_type == FillerType.ChestEquipment:
+            item = world.random.choice(chest_equipment)
+
+        elif filler_type == FillerType.NonVanillaEquipment:
+            item = world.random.choice(non_vanilla)
+
+        elif filler_type == FillerType.ShopArtifacts:
+            item = world.random.choice(shop_artifacts)
+
+        elif filler_type == FillerType.ShopBasicEquipment:
+            item = world.random.choice(shop_basic_equipment)
 
         elif filler_type == FillerType.Coins:
             item = world.random.choice(vanilla_coins)
@@ -376,8 +386,17 @@ def create_filler_pool_weights(world: 'GSTLAWorld') -> Dict[FillerType, int]:
     if world.options.lucky_equipment_filler_weight > 0:
         filler_pool_weights[FillerType.LuckyEquipment] = world.options.lucky_equipment_filler_weight
 
-    if world.options.shop_equipment_filler_weight > 0:
-        filler_pool_weights[FillerType.ShopEquipment] = world.options.shop_equipment_filler_weight
+    if world.options.chest_equipment_filler_weight > 0:
+        filler_pool_weights[FillerType.ChestEquipment] = world.options.chest_equipment_filler_weight
+
+    if world.options.non_vanilla_equipment_filler_weight > 0:
+        filler_pool_weights[FillerType.NonVanillaEquipment] = world.options.non_vanilla_equipment_filler_weight
+
+    if world.options.shop_artifacts_filler_weight > 0:
+        filler_pool_weights[FillerType.ShopArtifacts] = world.options.shop_artifacts_filler_weight
+
+    if world.options.shop_basic_equipment_filler_weight > 0:
+        filler_pool_weights[FillerType.ShopBasicEquipment] = world.options.shop_basic_equipment_filler_weight
 
     if world.options.coins_filler_weight > 0:
         filler_pool_weights[FillerType.Coins] = world.options.coins_filler_weight

--- a/worlds/gstla/Option_groups.py
+++ b/worlds/gstla/Option_groups.py
@@ -1,25 +1,22 @@
-from Options import StartInventoryPool
-from .Options import (ItemShuffle, RevealHiddenItem, OmitLocations, AddGs1Items, AddDummyItems,
-                      StartWithShip, ShipWings, AnemosAccess, CharacterShuffle, SecondStartingCharacter,
-                      CharStatShuffle, CharEleShuffle, NoLearningUtilPsy, RandomizeClassStatBoosts,
-                      ClassPsynergy, ClassPsynergyLevels, AdjustPsyPower, AdjustPsyCost, RandomizePsyAoe,
-                      AdjustEnemyPsyPower, RandomizeEnemyPsyAoe, EnemyEResShuffle, StartWithHealPsynergy,
-                      StartWithRevivePsynergy, DjinnShuffle, DjinnLogic,
-                      ShuffleDjinnStats, AdjustDjinnPower, RandomizeDjinnAoe, ScaleDjinnBattleDifficulty,
-                      RandomizeSummonCosts, AdjustSummonPower, RandomizeEqCompatibility, AdjustEqPrices,
-                      AdjustEqStats, ShuffleAttack, ShuffleWpnEffects, ShuffleDefense, ShuffleArmEffect,
-                      RandomizeEqCurses, RemoveCurses, VisibleItems, FreeAvoid, FreeRetreat, ScaleExpGained,
-                      ScaleCoinsGained, StartingLevels, SanctuaryReviveCost, AvoidPatch, EnableHardMode,
-                      HalveEncounterRate, EasierBosses, NamedPuzzles, ManualRetreatGlitch, MusicShuffle,
-                      TelportEverywhere, TrapChance, MimicTrapWeight, ForgeMaterialsFillerWeight,
-                      RustyMaterialsFillerWeight, StatBoostFillerWeight, UncommonConsumableFillerWeight,
-                      ForgedEquipmentFillerWeight, LuckyEquipmentFillerWeight, ShopEquipmentFillerWeight,
-                      CoinsFillerWeight, CommonConsumablesFillerWeight, AutoRun, ScaleMimics, ScaleCharacters,
-                      MaxScaledLevel, ForgeMaterialsAreFiller, ArtifactsAreFiller, DisableShopGameTickets,
-                      Goal, RandomGoals, DjinnHuntCount, SummonHuntCount, ShortcutMarsLighthouse, ShortcutMagmaRock)
-
 from Options import OptionGroup
-
+from .Options import (NonVanillaEquipmentFillerWeight, ShopArtifactsFillerWeight, ShopBasicEquipmentFillerWeight,
+                      ItemShuffle, RevealHiddenItem, OmitLocations, AddGs1Items, AddDummyItems, StartWithShip,
+                      ShipWings, AnemosAccess, CharacterShuffle, SecondStartingCharacter, CharStatShuffle,
+                      CharEleShuffle, NoLearningUtilPsy, RandomizeClassStatBoosts, ClassPsynergy, ClassPsynergyLevels,
+                      AdjustPsyPower, AdjustPsyCost, RandomizePsyAoe, AdjustEnemyPsyPower, RandomizeEnemyPsyAoe,
+                      EnemyEResShuffle, StartWithHealPsynergy, StartWithRevivePsynergy, DjinnShuffle, DjinnLogic,
+                      ShuffleDjinnStats, AdjustDjinnPower, RandomizeDjinnAoe, ScaleDjinnBattleDifficulty,
+                      RandomizeSummonCosts, AdjustSummonPower, RandomizeEqCompatibility, AdjustEqPrices, AdjustEqStats,
+                      ShuffleAttack, ShuffleWpnEffects, ShuffleDefense, ShuffleArmEffect, RandomizeEqCurses,
+                      RemoveCurses, VisibleItems, FreeAvoid, FreeRetreat, ScaleExpGained, ScaleCoinsGained,
+                      StartingLevels, SanctuaryReviveCost, AvoidPatch, EnableHardMode, HalveEncounterRate, EasierBosses,
+                      NamedPuzzles, ManualRetreatGlitch, MusicShuffle, TelportEverywhere, TrapChance, MimicTrapWeight,
+                      ForgeMaterialsFillerWeight, RustyMaterialsFillerWeight, StatBoostFillerWeight,
+                      UncommonConsumableFillerWeight, ForgedEquipmentFillerWeight, LuckyEquipmentFillerWeight,
+                      CoinsFillerWeight, CommonConsumablesFillerWeight, AutoRun, ScaleMimics, ScaleCharacters,
+                      MaxScaledLevel, ForgeMaterialsAreFiller, ArtifactsAreFiller, DisableShopGameTickets, Goal,
+                      RandomGoals, DjinnHuntCount, SummonHuntCount, ShortcutMarsLighthouse, ShortcutMagmaRock,
+                      ChestEquipmentFillerWeight)
 
 gstla_option_groups = [
     OptionGroup("General Pool", [
@@ -116,7 +113,10 @@ gstla_option_groups = [
         UncommonConsumableFillerWeight,
         ForgedEquipmentFillerWeight,
         LuckyEquipmentFillerWeight,
-        ShopEquipmentFillerWeight,
+        ChestEquipmentFillerWeight,
+        NonVanillaEquipmentFillerWeight,
+        ShopArtifactsFillerWeight,
+        ShopBasicEquipmentFillerWeight,
         CoinsFillerWeight,
         CommonConsumablesFillerWeight
     ])

--- a/worlds/gstla/Option_presets.py
+++ b/worlds/gstla/Option_presets.py
@@ -1,23 +1,15 @@
 from typing import Any, Dict
-from Options import StartInventoryPool
-from .Options import (ItemShuffle, RevealHiddenItem, OmitLocations, AddGs1Items, AddDummyItems,
-                      StartWithShip, ShipWings, AnemosAccess, CharacterShuffle, SecondStartingCharacter,
-                      CharStatShuffle, CharEleShuffle, NoLearningUtilPsy, RandomizeClassStatBoosts,
-                      ClassPsynergy, ClassPsynergyLevels, AdjustPsyPower, AdjustPsyCost, RandomizePsyAoe,
-                      AdjustEnemyPsyPower, RandomizeEnemyPsyAoe, EnemyEResShuffle, StartWithHealPsynergy,
-                      StartWithRevivePsynergy, DjinnShuffle, DjinnLogic,
+from .Options import (ItemShuffle, RevealHiddenItem, OmitLocations, AddGs1Items, AddDummyItems, StartWithShip,
+                      ShipWings, AnemosAccess, CharacterShuffle, SecondStartingCharacter, CharStatShuffle,
+                      CharEleShuffle, NoLearningUtilPsy, RandomizeClassStatBoosts, ClassPsynergy, ClassPsynergyLevels,
+                      AdjustPsyPower, AdjustPsyCost, RandomizePsyAoe, AdjustEnemyPsyPower, RandomizeEnemyPsyAoe,
+                      EnemyEResShuffle, StartWithHealPsynergy, StartWithRevivePsynergy, DjinnShuffle, DjinnLogic,
                       ShuffleDjinnStats, AdjustDjinnPower, RandomizeDjinnAoe, ScaleDjinnBattleDifficulty,
-                      RandomizeSummonCosts, AdjustSummonPower, RandomizeEqCompatibility, AdjustEqPrices,
-                      AdjustEqStats, ShuffleAttack, ShuffleWpnEffects, ShuffleDefense, ShuffleArmEffect,
-                      RandomizeEqCurses, RemoveCurses, VisibleItems, FreeAvoid, FreeRetreat, ScaleExpGained,
-                      ScaleCoinsGained, StartingLevels, SanctuaryReviveCost, AvoidPatch, EnableHardMode,
-                      HalveEncounterRate, EasierBosses, NamedPuzzles, ManualRetreatGlitch, MusicShuffle,
-                      TelportEverywhere, TrapChance, MimicTrapWeight, ForgeMaterialsFillerWeight,
-                      RustyMaterialsFillerWeight, StatBoostFillerWeight, UncommonConsumableFillerWeight,
-                      ForgedEquipmentFillerWeight, LuckyEquipmentFillerWeight, ShopEquipmentFillerWeight,
-                      CoinsFillerWeight, CommonConsumablesFillerWeight, AutoRun, ScaleMimics, ScaleCharacters,
-                      MaxScaledLevel, ForgeMaterialsAreFiller, ArtifactsAreFiller, DisableShopGameTickets,
-                      Goal, RandomGoals, DjinnHuntCount, SummonHuntCount)
+                      RandomizeSummonCosts, AdjustSummonPower, RandomizeEqCompatibility, AdjustEqPrices, AdjustEqStats,
+                      ShuffleAttack, ShuffleWpnEffects, ShuffleDefense, ShuffleArmEffect, RandomizeEqCurses,
+                      RemoveCurses, VisibleItems, FreeAvoid, FreeRetreat, ScaleExpGained, ScaleCoinsGained,
+                      StartingLevels, SanctuaryReviveCost, AvoidPatch, EnableHardMode, HalveEncounterRate, EasierBosses,
+                      NamedPuzzles, ManualRetreatGlitch, MusicShuffle, TelportEverywhere)
 
 easy = {
     ItemShuffle.internal_name: ItemShuffle.option_all_chests_and_tablets,

--- a/worlds/gstla/Options.py
+++ b/worlds/gstla/Options.py
@@ -575,11 +575,41 @@ class LuckyEquipmentFillerWeight(Range):
     range_end = 100
     default = 0
 
-class ShopEquipmentFillerWeight(Range):
-    """The weight for a filler item to be equipment from the shop.
-    These include the normal things you can buy amongst a few of the artefacts. Think along the lines of Long Sword, Silver Helm, Chain Mail to a Frost Wand."""
-    internal_name = "shop_equipment_filler_weight"
-    display_name = "Shop Equipment Filler Weight"
+class ChestEquipmentFillerWeight(Range):
+    """The weight for a filler item to be equipment from a chest.
+    This is any equipment found in a chest, crate, or similar in the game.
+    Examples include Fire Brand, Sol Blade, Masamune, Turtle Boots, and Unicorn Ring."""
+    internal_name = "chest_equipment_filler_weight"
+    display_name = "Chest Equipment Filler Weight"
+    range_start = 0
+    range_end = 100
+    default = 10
+
+class NonVanillaEquipmentFillerWeight(Range):
+    """The weight for a filler item to be equipment unavailable in vanilla GS2.
+    This is any equipment not found in a vanilla playthrough of GS2 if you collect all the limited quantity items.
+    Examples include Arctic Blade, Gaia Blade, Muramasa, Machete, and Elven Rapier"""
+    internal_name = "non_vanilla_equipment_filler_weight"
+    display_name = "Non Vanilla Equipment Filler Weight"
+    range_start = 0
+    range_end = 100
+    default = 10
+
+class ShopArtifactsFillerWeight(Range):
+    """The weight for a filler item to be equipment originally from the artifacts menu of shops.
+    This is any of the equipment originally found in the artifacts menu of an equipment shop.
+    Examples include Shamshir, Silver Blade, Ninja Blade, Swift Sword, and Dragon Axe."""
+    internal_name = "shop_artifacts_filler_weight"
+    display_name = "Shop Artifacts Filler Weight"
+    range_start = 0
+    range_end = 100
+    default = 10
+
+class ShopBasicEquipmentFillerWeight(Range):
+    """The weight for a filler item to be basic equipment from the shop.
+    These include the normal things you can buy infinitely. Think along the lines of Long Sword, Silver Helm, or Chain Mail."""
+    internal_name = "shop_basic_equipment_filler_weight"
+    display_name = "Shop Basic Equipment Filler Weight"
     range_start = 0
     range_end = 100
     default = 10
@@ -837,6 +867,9 @@ class GSTLAOptions(PerGameCommonOptions):
     forged_equipment_filler_weight: ForgedEquipmentFillerWeight
     lucky_equipment_filler_weight: LuckyEquipmentFillerWeight
     artifacts_are_filler: ArtifactsAreFiller
-    shop_equipment_filler_weight: ShopEquipmentFillerWeight
+    chest_equipment_filler_weight: ChestEquipmentFillerWeight
+    non_vanilla_equipment_filler_weight: NonVanillaEquipmentFillerWeight
+    shop_artifacts_filler_weight: ShopArtifactsFillerWeight
+    shop_basic_equipment_filler_weight: ShopBasicEquipmentFillerWeight
     coins_filler_weight: CoinsFillerWeight
     common_consumable_filler_weight: CommonConsumablesFillerWeight

--- a/worlds/gstla/__init__.py
+++ b/worlds/gstla/__init__.py
@@ -178,7 +178,8 @@ class GSTLAWorld(World):
         #ensure that if all are set to 0 we force them all to 1, otherwise we can not create filler and clearly they wanted all to be the same weight.
         combined_weight = self.options.forge_material_filler_weight + self.options.rusty_material_filler_weight + self.options.stat_boost_filler_weight
         combined_weight += self.options.uncommon_consumable_filler_weight + self.options.forged_equipment_filler_weight + self.options.lucky_equipment_filler_weight
-        combined_weight += self.options.shop_equipment_filler_weight + self.options.coins_filler_weight + self.options.common_consumable_filler_weight
+        combined_weight += self.options.chest_equipment_filler_weight + self.options.non_vanilla_equipment_filler_weight + self.options.shop_artifacts_filler_weight
+        combined_weight += self.options.shop_basic_equipment_filler_weight + self.options.coins_filler_weight + self.options.common_consumable_filler_weight
 
         if combined_weight == 0:
             self.options.forge_material_filler_weight.value = 1
@@ -187,7 +188,10 @@ class GSTLAWorld(World):
             self.options.uncommon_consumable_filler_weight.value = 1
             self.options.forged_equipment_filler_weight.value = 1
             self.options.lucky_equipment_filler_weight.value = 1
-            self.options.shop_equipment_filler_weight.value = 1
+            self.options.chest_equipment_filler_weight.value = 1
+            self.options.non_vanilla_equipment_filler_weight.value = 1
+            self.options.shop_artifacts_filler_weight.value = 1
+            self.options.shop_basic_equipment_filler_weight.value = 1
             self.options.coins_filler_weight.value = 1
             self.options.common_consumable_filler_weight.value = 1
 

--- a/worlds/gstla/archipelago.json
+++ b/worlds/gstla/archipelago.json
@@ -1,7 +1,7 @@
 {
   "game": "Golden Sun The Lost Age",
-  "authors": ["Dragion", "Platano Bailando", "Karanum"],
+  "authors": ["Dragion", "Platano Bailando", "Karanum", "Knives"],
   "minimum_ap_version": "0.6.7",
-  "world_version": "0.2.3",
+  "world_version": "0.2.4",
   "tracker": "https://github.com/cloudofdarkhole6/GSTLAPopTracker/releases"
 }

--- a/worlds/gstla/gen/InternalItemData.py
+++ b/worlds/gstla/gen/InternalItemData.py
@@ -315,7 +315,7 @@ stat_boosters = [
 
 
 
-useful_remainder = [
+chest_equipment = [
     
         InternalItemData(384, name_by_item_id[384], ItemClassification.useful, 746852, ItemType.Helm, False, True),
         InternalItemData(259, name_by_item_id[259], ItemClassification.useful, 741352, ItemType.Boots, False, True),
@@ -354,31 +354,15 @@ useful_remainder = [
         InternalItemData(383, name_by_item_id[383], ItemClassification.useful, 746808, ItemType.Helm, False, True),
 ]
 
-other_useful: List[InternalItemData] = useful_remainder  + useful_consumables  + forge_materials  + class_change_items 
+other_useful: List[InternalItemData] = chest_equipment  + useful_consumables  + forge_materials  + class_change_items 
 
-shop_only: List[InternalItemData] = [
-InternalItemData(1, name_by_item_id[1], ItemClassification.filler, 730000, ItemType.Weapon, False, False),
-InternalItemData(2, name_by_item_id[2], ItemClassification.filler, 730044, ItemType.Weapon, False, False),
-InternalItemData(3, name_by_item_id[3], ItemClassification.filler, 730088, ItemType.Weapon, False, False),
-InternalItemData(4, name_by_item_id[4], ItemClassification.filler, 730132, ItemType.Weapon, False, False),
+shop_artifacts: List[InternalItemData] = [
 InternalItemData(5, name_by_item_id[5], ItemClassification.useful, 730176, ItemType.Weapon, False, True),
 InternalItemData(6, name_by_item_id[6], ItemClassification.useful, 730220, ItemType.Weapon, False, True),
-InternalItemData(16, name_by_item_id[16], ItemClassification.filler, 730660, ItemType.Weapon, False, False),
-InternalItemData(17, name_by_item_id[17], ItemClassification.filler, 730704, ItemType.Weapon, False, False),
-InternalItemData(18, name_by_item_id[18], ItemClassification.filler, 730748, ItemType.Weapon, False, False),
-InternalItemData(19, name_by_item_id[19], ItemClassification.filler, 730792, ItemType.Weapon, False, False),
 InternalItemData(20, name_by_item_id[20], ItemClassification.useful, 730836, ItemType.Weapon, False, True),
 InternalItemData(21, name_by_item_id[21], ItemClassification.useful, 730880, ItemType.Weapon, False, True),
-InternalItemData(31, name_by_item_id[31], ItemClassification.filler, 731320, ItemType.Weapon, False, False),
-InternalItemData(32, name_by_item_id[32], ItemClassification.filler, 731364, ItemType.Weapon, False, False),
-InternalItemData(33, name_by_item_id[33], ItemClassification.filler, 731408, ItemType.Weapon, False, False),
 InternalItemData(34, name_by_item_id[34], ItemClassification.useful, 731452, ItemType.Weapon, False, True),
-InternalItemData(43, name_by_item_id[43], ItemClassification.filler, 731848, ItemType.Weapon, False, False),
-InternalItemData(44, name_by_item_id[44], ItemClassification.filler, 731892, ItemType.Weapon, False, False),
-InternalItemData(45, name_by_item_id[45], ItemClassification.filler, 731936, ItemType.Weapon, False, False),
-InternalItemData(46, name_by_item_id[46], ItemClassification.filler, 731980, ItemType.Weapon, False, False),
 InternalItemData(47, name_by_item_id[47], ItemClassification.useful, 732024, ItemType.Weapon, False, True),
-InternalItemData(55, name_by_item_id[55], ItemClassification.filler, 732376, ItemType.Weapon, False, False),
 InternalItemData(56, name_by_item_id[56], ItemClassification.useful, 732420, ItemType.Weapon, False, True),
 InternalItemData(57, name_by_item_id[57], ItemClassification.useful, 732464, ItemType.Weapon, False, True),
 InternalItemData(58, name_by_item_id[58], ItemClassification.useful, 732508, ItemType.Weapon, False, True),
@@ -387,6 +371,34 @@ InternalItemData(60, name_by_item_id[60], ItemClassification.useful, 732596, Ite
 InternalItemData(61, name_by_item_id[61], ItemClassification.useful, 732640, ItemType.Weapon, False, True),
 InternalItemData(62, name_by_item_id[62], ItemClassification.useful, 732684, ItemType.Weapon, False, True),
 InternalItemData(63, name_by_item_id[63], ItemClassification.useful, 732728, ItemType.Weapon, False, True),
+InternalItemData(109, name_by_item_id[109], ItemClassification.useful, 734752, ItemType.Armor, False, True),
+InternalItemData(110, name_by_item_id[110], ItemClassification.useful, 734796, ItemType.Armor, False, True),
+InternalItemData(111, name_by_item_id[111], ItemClassification.useful, 734840, ItemType.Armor, False, True),
+InternalItemData(122, name_by_item_id[122], ItemClassification.useful, 735324, ItemType.Shield, False, True),
+InternalItemData(131, name_by_item_id[131], ItemClassification.useful, 735720, ItemType.Shield, False, True),
+InternalItemData(140, name_by_item_id[140], ItemClassification.useful, 736116, ItemType.Shield, False, True),
+InternalItemData(159, name_by_item_id[159], ItemClassification.useful, 736952, ItemType.Helm, False, True),
+InternalItemData(404, name_by_item_id[404], ItemClassification.useful, 747732, ItemType.Boots, False, True),
+
+]
+
+shop_basic_equipment: List[InternalItemData] = [
+InternalItemData(1, name_by_item_id[1], ItemClassification.filler, 730000, ItemType.Weapon, False, False),
+InternalItemData(2, name_by_item_id[2], ItemClassification.filler, 730044, ItemType.Weapon, False, False),
+InternalItemData(3, name_by_item_id[3], ItemClassification.filler, 730088, ItemType.Weapon, False, False),
+InternalItemData(4, name_by_item_id[4], ItemClassification.filler, 730132, ItemType.Weapon, False, False),
+InternalItemData(16, name_by_item_id[16], ItemClassification.filler, 730660, ItemType.Weapon, False, False),
+InternalItemData(17, name_by_item_id[17], ItemClassification.filler, 730704, ItemType.Weapon, False, False),
+InternalItemData(18, name_by_item_id[18], ItemClassification.filler, 730748, ItemType.Weapon, False, False),
+InternalItemData(19, name_by_item_id[19], ItemClassification.filler, 730792, ItemType.Weapon, False, False),
+InternalItemData(31, name_by_item_id[31], ItemClassification.filler, 731320, ItemType.Weapon, False, False),
+InternalItemData(32, name_by_item_id[32], ItemClassification.filler, 731364, ItemType.Weapon, False, False),
+InternalItemData(33, name_by_item_id[33], ItemClassification.filler, 731408, ItemType.Weapon, False, False),
+InternalItemData(43, name_by_item_id[43], ItemClassification.filler, 731848, ItemType.Weapon, False, False),
+InternalItemData(44, name_by_item_id[44], ItemClassification.filler, 731892, ItemType.Weapon, False, False),
+InternalItemData(45, name_by_item_id[45], ItemClassification.filler, 731936, ItemType.Weapon, False, False),
+InternalItemData(46, name_by_item_id[46], ItemClassification.filler, 731980, ItemType.Weapon, False, False),
+InternalItemData(55, name_by_item_id[55], ItemClassification.filler, 732376, ItemType.Weapon, False, False),
 InternalItemData(75, name_by_item_id[75], ItemClassification.filler, 733256, ItemType.Armor, False, False),
 InternalItemData(76, name_by_item_id[76], ItemClassification.filler, 733300, ItemType.Armor, False, False),
 InternalItemData(77, name_by_item_id[77], ItemClassification.filler, 733344, ItemType.Armor, False, False),
@@ -401,23 +413,17 @@ InternalItemData(103, name_by_item_id[103], ItemClassification.filler, 734488, I
 InternalItemData(104, name_by_item_id[104], ItemClassification.filler, 734532, ItemType.Armor, False, False),
 InternalItemData(105, name_by_item_id[105], ItemClassification.filler, 734576, ItemType.Armor, False, False),
 InternalItemData(107, name_by_item_id[107], ItemClassification.filler, 734664, ItemType.Armor, False, False),
-InternalItemData(109, name_by_item_id[109], ItemClassification.useful, 734752, ItemType.Armor, False, True),
-InternalItemData(110, name_by_item_id[110], ItemClassification.useful, 734796, ItemType.Armor, False, True),
-InternalItemData(111, name_by_item_id[111], ItemClassification.useful, 734840, ItemType.Armor, False, True),
 InternalItemData(118, name_by_item_id[118], ItemClassification.filler, 735148, ItemType.Shield, False, False),
 InternalItemData(119, name_by_item_id[119], ItemClassification.filler, 735192, ItemType.Shield, False, False),
 InternalItemData(120, name_by_item_id[120], ItemClassification.filler, 735236, ItemType.Shield, False, False),
 InternalItemData(121, name_by_item_id[121], ItemClassification.filler, 735280, ItemType.Shield, False, False),
-InternalItemData(122, name_by_item_id[122], ItemClassification.useful, 735324, ItemType.Shield, False, True),
 InternalItemData(127, name_by_item_id[127], ItemClassification.filler, 735544, ItemType.Shield, False, False),
 InternalItemData(128, name_by_item_id[128], ItemClassification.filler, 735588, ItemType.Shield, False, False),
 InternalItemData(129, name_by_item_id[129], ItemClassification.filler, 735632, ItemType.Shield, False, False),
-InternalItemData(131, name_by_item_id[131], ItemClassification.useful, 735720, ItemType.Shield, False, True),
 InternalItemData(136, name_by_item_id[136], ItemClassification.filler, 735940, ItemType.Shield, False, False),
 InternalItemData(137, name_by_item_id[137], ItemClassification.filler, 735984, ItemType.Shield, False, False),
 InternalItemData(138, name_by_item_id[138], ItemClassification.filler, 736028, ItemType.Shield, False, False),
 InternalItemData(139, name_by_item_id[139], ItemClassification.filler, 736072, ItemType.Shield, False, False),
-InternalItemData(140, name_by_item_id[140], ItemClassification.useful, 736116, ItemType.Shield, False, True),
 InternalItemData(145, name_by_item_id[145], ItemClassification.filler, 736336, ItemType.Helm, False, False),
 InternalItemData(146, name_by_item_id[146], ItemClassification.filler, 736380, ItemType.Helm, False, False),
 InternalItemData(147, name_by_item_id[147], ItemClassification.filler, 736424, ItemType.Helm, False, False),
@@ -427,13 +433,11 @@ InternalItemData(150, name_by_item_id[150], ItemClassification.filler, 736556, I
 InternalItemData(156, name_by_item_id[156], ItemClassification.filler, 736820, ItemType.Helm, False, False),
 InternalItemData(157, name_by_item_id[157], ItemClassification.filler, 736864, ItemType.Helm, False, False),
 InternalItemData(158, name_by_item_id[158], ItemClassification.filler, 736908, ItemType.Helm, False, False),
-InternalItemData(159, name_by_item_id[159], ItemClassification.useful, 736952, ItemType.Helm, False, True),
 InternalItemData(166, name_by_item_id[166], ItemClassification.filler, 737260, ItemType.Helm, False, False),
 InternalItemData(167, name_by_item_id[167], ItemClassification.filler, 737304, ItemType.Helm, False, False),
 InternalItemData(168, name_by_item_id[168], ItemClassification.filler, 737348, ItemType.Helm, False, False),
 InternalItemData(169, name_by_item_id[169], ItemClassification.filler, 737392, ItemType.Helm, False, False),
 InternalItemData(402, name_by_item_id[402], ItemClassification.useful, 747644, ItemType.Boots, False, False),
-InternalItemData(404, name_by_item_id[404], ItemClassification.useful, 747732, ItemType.Boots, False, True),
 
 ]
 
@@ -654,6 +658,8 @@ remainder: List[InternalItemData] = [
     InternalItemData(241, name_by_item_id[241], ItemClassification.filler, 740560, ItemType.Consumable, False, False),
     
 ]
+
+shop_only: List[InternalItemData] = shop_basic_equipment + shop_artifacts
 
 all_items: List[InternalItemData] = djinn_items + psyenergy_as_item_list + psyenergy_list + summon_list + events + characters + \
     mimics + other_progression + other_useful + shop_only + forge_only + lucky_only + non_vanilla + vanilla_coins + \

--- a/worlds/gstla/gen/ItemData.py
+++ b/worlds/gstla/gen/ItemData.py
@@ -29,7 +29,10 @@ class FillerType(str, Enum):
     UsefulConsumables = "Useful Consumables"
     ForgedEquipment = "Forged Equipment"
     LuckyEquipment = "Lucky Equipment"
-    ShopEquipment = "Shop Equipment"
+    ChestEquipment = "Chest Equipment"
+    NonVanillaEquipment = "Non Vanilla Equipment"
+    ShopArtifacts = "Shop Artifacts"
+    ShopBasicEquipment = "Shop Basic Equipment"
     Coins = "Coins"
     CommonConsumables = "Common Consumables"
 
@@ -131,11 +134,13 @@ forge_materials: List[ItemData] = _convert_data(ItemLists.forge_materials)
 class_change_items: List[ItemData] = _convert_data(ItemLists.class_change_items)
 rusty_items: List[ItemData] = _convert_data(ItemLists.rusty_items)
 stat_boosters: List[ItemData] = _convert_data(ItemLists.stat_boosters)
-useful_remainder = _convert_data(ItemLists.useful_remainder)
+chest_equipment = _convert_data(ItemLists.chest_equipment)
 
-other_useful: List[ItemData] = useful_remainder + useful_consumables + forge_materials + class_change_items
+other_useful: List[ItemData] = chest_equipment + useful_consumables + forge_materials + class_change_items
 
 shop_only: List[ItemData] = _convert_data(ItemLists.shop_only)
+shop_artifacts: List[ItemData] = _convert_data(ItemLists.shop_artifacts)
+shop_basic_equipment: List[ItemData] = _convert_data(ItemLists.shop_basic_equipment)
 forge_only: List[ItemData] = _convert_data(ItemLists.forge_only)
 lucky_only: List[ItemData] = _convert_data(ItemLists.lucky_only)
 
@@ -145,9 +150,9 @@ vanilla_coins: List[ItemData] = _convert_data(ItemLists.vanilla_coins)
 misc: List[ItemData] = _convert_data(ItemLists.misc)
 remainder: List[ItemData] = _convert_data(ItemLists.remainder)
 
-all_items: List[ItemData] = djinn_items + psyenergy_as_item_list + psyenergy_list + summon_list + events + characters + \
-                            mimics + other_progression + other_useful + shop_only + forge_only + lucky_only + non_vanilla + vanilla_coins + \
-                            misc + rusty_items + stat_boosters + remainder
+all_items: List[ItemData] = djinn_items + psyenergy_as_item_list + psyenergy_list + summon_list + events + \
+                            characters + mimics + other_progression + other_useful + shop_only + forge_only + \
+                            lucky_only + non_vanilla + vanilla_coins + misc + rusty_items + stat_boosters + remainder
 assert len(all_items) == len({x.id for x in all_items})
 item_table: Dict[str, ItemData] = {item.name: item for item in all_items}
 items_by_id: Dict[int, ItemData] = {item.id: item for item in all_items}

--- a/worlds/gstla/gen/templates/ItemData.py.jinja
+++ b/worlds/gstla/gen/templates/ItemData.py.jinja
@@ -107,16 +107,22 @@ other_progression: List[InternalItemData] = [
 
 {% endfor %}
 
-useful_remainder = [
-    {% for id in useful_remainder -%}{% set item = other_useful[id] %}
+chest_equipment = [
+    {% for id in chest_equipment -%}{% set item = other_useful[id] %}
         InternalItemData({{item.item.id}}, name_by_item_id[{{item.name.id}}], ItemClassification.{{progression[item.item.id]}}, {{item.item.addr}}, {{item.item.item_type}}, {{item.item.is_mimic}}, {{item.item.flags | bitwise_and(4)}}),
 {%- endfor %}
 ]
 
-other_useful: List[InternalItemData] = useful_remainder {% for name in useful_groups.keys() %} + {{name}} {% endfor %}
+other_useful: List[InternalItemData] = chest_equipment {% for name in useful_groups.keys() %} + {{name}} {% endfor %}
 
-shop_only: List[InternalItemData] = [
-{% for item in shop_only -%}
+shop_artifacts: List[InternalItemData] = [
+{% for item in shop_artifacts -%}
+    InternalItemData({{item.item.id}}, name_by_item_id[{{item.name.id}}], ItemClassification.{{progression[item.item.id]}}, {{item.item.addr}}, {{item.item.item_type}}, {{item.item.is_mimic}}, {{item.item.flags | bitwise_and(4)}}),
+{% endfor %}
+]
+
+shop_basic_equipment: List[InternalItemData] = [
+{% for item in shop_basic_equipment -%}
     InternalItemData({{item.item.id}}, name_by_item_id[{{item.name.id}}], ItemClassification.{{progression[item.item.id]}}, {{item.item.addr}}, {{item.item.item_type}}, {{item.item.is_mimic}}, {{item.item.flags | bitwise_and(4)}}),
 {% endfor %}
 ]
@@ -156,6 +162,8 @@ remainder: List[InternalItemData] = [
     InternalItemData({{item.item.id}}, name_by_item_id[{{item.name.id}}], ItemClassification.{{progression[item.item.id]}}, {{item.item.addr}}, {{item.item.item_type}}, {{item.item.is_mimic}}, {{item.item.flags | bitwise_and(4)}}),
     {% endfor %}
 ]
+
+shop_only: List[InternalItemData] = shop_basic_equipment + shop_artifacts
 
 all_items: List[InternalItemData] = djinn_items + psyenergy_as_item_list + psyenergy_list + summon_list + events + characters + \
     mimics + other_progression + other_useful + shop_only + forge_only + lucky_only + non_vanilla + vanilla_coins + \

--- a/worlds/gstla/generate_code.py
+++ b/worlds/gstla/generate_code.py
@@ -265,7 +265,8 @@ def generate_item_data(env: Environment, data: GameData):
         other_prog = []
         other_useful = dict()
         other_items = dict()
-        shop_only = []
+        shop_basic_equipment = []
+        shop_artifacts = []
         forge_only = []
         lucky_only = []
         non_vanilla = []
@@ -279,12 +280,17 @@ def generate_item_data(env: Environment, data: GameData):
             231, # Bone
             449, # Laughing Fungus
         }
-        shop_only_ids = set()
+        shop_non_artifact_ids = set()
+        shop_artifact_ids = set()
         forge_only_ids = set()
         lucky_only_ids = set()
-        for id in data.vanilla_shop_contents:
+        for id in data.shop_basic_equipment:
             if id not in vanilla_item_ids:
-                shop_only_ids.add(id)
+                shop_non_artifact_ids.add(id)
+            vanilla_item_ids.add(id)
+        for id in data.shop_artifacts:
+            if id not in vanilla_item_ids:
+                shop_artifact_ids.add(id)
             vanilla_item_ids.add(id)
         for id in data.forgeable_ids:
             if id not in vanilla_item_ids:
@@ -320,8 +326,10 @@ def generate_item_data(env: Environment, data: GameData):
                 other_items[item.id] = datum
             elif CLASSIFICATION_OVERRIDES[item.id] == 'useful':
                 other_useful[item.id] = datum
-            elif item.id in shop_only_ids:
-                shop_only.append(datum)
+            elif item.id in shop_artifact_ids:
+                shop_artifacts.append(datum)
+            elif item.id in shop_non_artifact_ids:
+                shop_basic_equipment.append(datum)
             elif item.id in forge_only_ids:
                 forge_only.append(datum)
             elif item.id in lucky_only_ids:
@@ -336,10 +344,10 @@ def generate_item_data(env: Environment, data: GameData):
                 other_useful[item.id] = datum
             else:
                 remainder.append(datum)
-        useful_remainder_ids = set()
+        chest_equipment_ids = set()
         for usefuls in USEFUL_ITEM_GROUPS.values():
-            useful_remainder_ids |= usefuls
-        useful_remainder_ids = {x['item'].id for x in other_useful.values()} - useful_remainder_ids
+            chest_equipment_ids |= usefuls
+        chest_equipment_ids = {x['item'].id for x in other_useful.values()} - chest_equipment_ids
         outfile.write(template.render(
             summons=summons,
             psyenergies=psyenergies,
@@ -351,11 +359,12 @@ def generate_item_data(env: Environment, data: GameData):
             misc=misc,
             other_useful=other_useful,
             useful_groups=USEFUL_ITEM_GROUPS,
-            useful_remainder=useful_remainder_ids,
+            chest_equipment=chest_equipment_ids,
             other_items=other_items,
             other_groups=OTHER_ITEM_GROUPS,
             non_vanilla=non_vanilla,
-            shop_only=shop_only,
+            shop_artifacts=shop_artifacts,
+            shop_basic_equipment=shop_basic_equipment,
             forge_only=forge_only,
             lucky_only=lucky_only,
             vanilla_coins=vanilla_coins,


### PR DESCRIPTION
## What is this fixing or adding?
This is adding more options for filler items.
It removes the shop only filler option, and introduces two filler options to replace it:
Shop Artifacts and Shop Basic Equipment
It also adds Non-Vanilla and Chest Equipment as filler options.

## How was this tested?
I generated multiple multiworlds with the built apworld from the "build apworlds" pycharm configuration.
I used server hints to verify the generation of filler items according to weights.

Let me know if I need to make changes or adjustments.