### PR TITLE
Put current map and entrance into Data Storage

### DIFF
--- a/worlds/gstla/BizClient.py
+++ b/worlds/gstla/BizClient.py
@@ -357,11 +357,8 @@ class GSTLAClient(BizHawkClient):
     def get_djinn_possessed_key(self, ctx: 'BizHawkClientContext') -> str:
         return f"gstla_djinn_held_{ctx.slot}_{ctx.team}"
 
-    def get_current_map_key(self, ctx: 'BizHawkClientContext') -> str:
-        return f"gstla_current_map_{ctx.slot}_{ctx.team}"
-
-    def get_current_entrance_key(self, ctx: 'BizHawkClientContext') -> str:
-        return f"gstla_current_entrance_{ctx.slot}_{ctx.team}"
+    def get_map_info_key(self, ctx: 'BizHawkClientContext') -> str:
+        return f"gstla_map_info_{ctx.slot}_{ctx.team}"
 
     def check_summon_count(self, ctx: "BizHawkClientContext") -> None:
         if self.summon_item_index >= len(ctx.items_received):
@@ -599,13 +596,12 @@ class GSTLAClient(BizHawkClient):
             if self.temp_events:
                 await ctx.send_msgs([{
                     "cmd": "Set",
-                    "operation": "update",
                     "want_reply": True,
                     "key": self.get_event_key(ctx),
                     "default": [],
                     "operations": [
                         {
-                            "operation": "update",
+                            "operation": "replace",
                             "value": [x for x in self.temp_events],
                         }
                     ]
@@ -615,25 +611,22 @@ class GSTLAClient(BizHawkClient):
         await self.goals.check_goals(self, ctx)
 
         current_map = int.from_bytes(result[_DataLocations.MAP_ID], 'little')
-        if current_map != self.last_map:
-            self.last_map = current_map
-            await ctx.send_msgs([{
-                "cmd": "Set",
-                "key": self.get_current_map_key(ctx),
-                "default": 0,
-                "want_reply": False,
-                "operations": [{"operation": "replace", "value": current_map}]
-            }])
-
         current_entrance = int.from_bytes(result[_DataLocations.ENTRANCE_ID], 'little')
-        if current_entrance != self.last_entrance:
+        if current_map != self.last_map or current_entrance != self.last_entrance:
+            self.last_map = current_map
             self.last_entrance = current_entrance
             await ctx.send_msgs([{
                 "cmd": "Set",
-                "key": self.get_current_entrance_key(ctx),
-                "default": 0,
+                "key": self.get_map_info_key(ctx),
+                "default": {},
                 "want_reply": False,
-                "operations": [{"operation": "replace", "value": current_entrance}]
+                "operations": [{
+                    "operation": "update",
+                    "value": {
+                        "map": current_map,
+                        "entrance": current_entrance
+                    }
+                }]
             }])
 
         if not ctx.finished_game and self.goals.is_done(self, ctx):

--- a/worlds/gstla/BizClient.py
+++ b/worlds/gstla/BizClient.py
@@ -621,7 +621,7 @@ class GSTLAClient(BizHawkClient):
                 "default": {},
                 "want_reply": False,
                 "operations": [{
-                    "operation": "update",
+                    "operation": "replace",
                     "value": {
                         "map": current_map,
                         "entrance": current_entrance

--- a/worlds/gstla/BizClient.py
+++ b/worlds/gstla/BizClient.py
@@ -31,7 +31,8 @@ class _MemDomain(str, Enum):
     ROM = 'ROM'
 
 class _DataLocations(IntEnum):
-    IN_GAME = (0x428, 0x2, 0x0, _MemDomain.EWRAM)
+    MAP_ID = (0x428, 0x2, 0x0, _MemDomain.EWRAM)
+    ENTRANCE_ID = (0x42A, 0x2, 0x0, _MemDomain.EWRAM)
     DJINN_FLAGS = (FLAG_START + (0x30 >> 3), 0x0A, 0x30, _MemDomain.EWRAM)
     AP_ITEM_SLOT = (0xA96, 0x2, 0x0, _MemDomain.EWRAM)
     # two unused bytes in save data
@@ -293,6 +294,8 @@ class GSTLAClient(BizHawkClient):
         self.coop: int = 0
         self.remote_blacklist: Set[int] = remote_blacklist
         self.goals = GoalManager()
+        self.last_map: int = 0
+        self.last_entrance: int = 0
 
     async def validate_rom(self, ctx: 'BizHawkClientContext'):
         from worlds._bizhawk.context import TextCategory
@@ -338,10 +341,9 @@ class GSTLAClient(BizHawkClient):
             self.djinn_ram_to_rom[rom_flag] = djinn_flag
 
     def _is_in_game(self, data: List[bytes]) -> bool:
-        # What the emo tracker pack does; seems like it also verifies the player
-        # has opened a save file
-        flag = int.from_bytes(data[_DataLocations.IN_GAME], 'little')
-        return flag > 1
+        # Map ID 0x00 and 0x01 are Title Screen and Clear Data respectively, everything greater is safe
+        current_map = int.from_bytes(data[_DataLocations.MAP_ID], 'little')
+        return current_map > 1
 
     def get_goal_flags_key(self, ctx: 'BizHawkClientContext') -> str:
         return f"gstla_goal_flags_status_{ctx.slot}_{ctx.team}"
@@ -354,6 +356,12 @@ class GSTLAClient(BizHawkClient):
 
     def get_djinn_possessed_key(self, ctx: 'BizHawkClientContext') -> str:
         return f"gstla_djinn_held_{ctx.slot}_{ctx.team}"
+
+    def get_current_map_key(self, ctx: 'BizHawkClientContext') -> str:
+        return f"gstla_current_map_{ctx.slot}_{ctx.team}"
+
+    def get_current_entrance_key(self, ctx: 'BizHawkClientContext') -> str:
+        return f"gstla_current_entrance_{ctx.slot}_{ctx.team}"
 
     def check_summon_count(self, ctx: "BizHawkClientContext") -> None:
         if self.summon_item_index >= len(ctx.items_received):
@@ -605,6 +613,28 @@ class GSTLAClient(BizHawkClient):
                 self.local_events = self.temp_events
 
         await self.goals.check_goals(self, ctx)
+
+        current_map = int.from_bytes(result[_DataLocations.MAP_ID], 'little')
+        if current_map != self.last_map:
+            self.last_map = current_map
+            await ctx.send_msgs([{
+                "cmd": "Set",
+                "key": self.get_current_map_key(ctx),
+                "default": 0,
+                "want_reply": False,
+                "operations": [{"operation": "replace", "value": current_map}]
+            }])
+
+        current_entrance = int.from_bytes(result[_DataLocations.ENTRANCE_ID], 'little')
+        if current_entrance != self.last_entrance:
+            self.last_entrance = current_entrance
+            await ctx.send_msgs([{
+                "cmd": "Set",
+                "key": self.get_current_entrance_key(ctx),
+                "default": 0,
+                "want_reply": False,
+                "operations": [{"operation": "replace", "value": current_entrance}]
+            }])
 
         if not ctx.finished_game and self.goals.is_done(self, ctx):
             await ctx.send_msgs([{"cmd": "StatusUpdate", "status": ClientStatus.CLIENT_GOAL}])

--- a/worlds/gstla/BizClient.py
+++ b/worlds/gstla/BizClient.py
@@ -596,12 +596,13 @@ class GSTLAClient(BizHawkClient):
             if self.temp_events:
                 await ctx.send_msgs([{
                     "cmd": "Set",
+                    "operation": "update",
                     "want_reply": True,
                     "key": self.get_event_key(ctx),
                     "default": [],
                     "operations": [
                         {
-                            "operation": "replace",
+                            "operation": "update",
                             "value": [x for x in self.temp_events],
                         }
                     ]

--- a/worlds/gstla/Options.py
+++ b/worlds/gstla/Options.py
@@ -617,9 +617,13 @@ class AutoRun(Toggle):
 
 class Coop(Choice):
     """Enables cooping a seed by making local items the same as remote items, enabling
-     your friends to receive items you pick up.  Also helpful if trying to play a world from multiple devices.
+     your friends to receive items you pick up. Also helpful if trying to play a world from multiple devices.
      You will still need to pickup djinn the other person picks up.
-     off - vanilla
+
+     Note: Due to current limitations, if you are enabling this to coop a seed and you want to use this game's PopTracker pack,
+     you should turn automatic tabbing off in the pack's settings to avoid constant map changes.
+
+     off - Vanilla
      progression - Only progression items are treated as remote items
      prog_useful - Progression and useful items are treated as remote items
      all - All items are treated as remote items


### PR DESCRIPTION
PR for https://github.com/cjmang/Archipelago/issues/57

Initially I thought just the map ID would be enough, but it seems like the entrance that gets used on transitions is also needed for some very messy dungeon layouts, where different floors will use the same map ID

I did also change `IN_GAME` to `MAP_ID` since that's what it seems to actually be, but let me know if you'd like that changed, along with anything else

Might want to wait on this a bit until I can verify entrance ID is enough? I figured this is a good proof of concept though